### PR TITLE
fix: upgrade vulnerable transitive deps via pnpm overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,16 @@
       "@cacheable/memory@2": "2.0.1",
       "@cacheable/utils@2": "2.0.1",
       "cacheable@2": "2.0.1",
-      "flat-cache@6": "6.1.14"
+      "flat-cache@6": "6.1.14",
+      "flatted@<3.4.2": "3.4.2",
+      "immutable@5": "5.1.9",
+      "lodash@4": "4.18.1",
+      "lodash-es@4": "4.18.1",
+      "minimatch@3": "3.1.5",
+      "minimatch@9": "9.0.9",
+      "minimatch@10": "10.2.6",
+      "picomatch@2": "2.3.2",
+      "picomatch@4": "4.0.5"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -155,11 +155,11 @@
       "flat-cache@6": "6.1.14",
       "flatted@<3.4.2": "3.4.2",
       "immutable@5": "5.1.9",
-      "lodash@4": "4.18.1",
       "lodash-es@4": "4.18.1",
+      "lodash@4": "4.18.1",
+      "minimatch@10": "10.2.6",
       "minimatch@3": "3.1.5",
       "minimatch@9": "9.0.9",
-      "minimatch@10": "10.2.6",
       "picomatch@2": "2.3.2",
       "picomatch@4": "4.0.5"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,10 +5,19 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  flat-cache@6: 6.1.14
-  cacheable@2: 2.0.1
   '@cacheable/memory@2': 2.0.1
   '@cacheable/utils@2': 2.0.1
+  cacheable@2: 2.0.1
+  flat-cache@6: 6.1.14
+  flatted@<3.4.2: 3.4.2
+  immutable@5: 5.1.9
+  lodash@4: 4.18.1
+  lodash-es@4: 4.18.1
+  minimatch@3: 3.1.5
+  minimatch@9: 9.0.9
+  minimatch@10: 10.2.6
+  picomatch@2: 2.3.2
+  picomatch@4: 4.0.5
 
 dependencies:
   '@tiptap/core':
@@ -191,14 +200,14 @@ devDependencies:
     specifier: ^15.2.11
     version: 15.5.2
   lodash:
-    specifier: ^4.17.21
-    version: 4.17.21
+    specifier: 4.18.1
+    version: 4.18.1
   lodash-es:
-    specifier: ^4.17.21
-    version: 4.17.21
+    specifier: 4.18.1
+    version: 4.18.1
   lodash-unified:
     specifier: ^1.0.3
-    version: 1.0.3(@types/lodash-es@4.17.12)(lodash-es@4.17.21)(lodash@4.17.21)
+    version: 1.0.3(@types/lodash-es@4.17.12)(lodash-es@4.18.1)(lodash@4.18.1)
   nodemon:
     specifier: ^3.1.9
     version: 3.1.10
@@ -938,7 +947,7 @@ packages:
     dependencies:
       '@eslint/object-schema': 2.1.6
       debug: 4.4.3(supports-color@5.5.0)
-      minimatch: 3.1.2
+      minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -973,7 +982,7 @@ packages:
       ignore: 5.3.2
       import-fresh: 3.3.1
       js-yaml: 4.1.0
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -1036,18 +1045,6 @@ packages:
     engines: {node: '>=18.18'}
     dev: true
 
-  /@isaacs/balanced-match@4.0.1:
-    resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
-    engines: {node: 20 || >=22}
-    dev: true
-
-  /@isaacs/brace-expansion@5.0.0:
-    resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
-    engines: {node: 20 || >=22}
-    dependencies:
-      '@isaacs/balanced-match': 4.0.1
-    dev: true
-
   /@jridgewell/sourcemap-codec@1.5.5:
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
@@ -1087,8 +1084,8 @@ packages:
       '@rushstack/rig-package': 0.5.3
       '@rushstack/terminal': 0.16.0(@types/node@24.5.1)
       '@rushstack/ts-command-line': 5.0.3(@types/node@24.5.1)
-      lodash: 4.17.21
-      minimatch: 10.0.3
+      lodash: 4.18.1
+      minimatch: 10.2.6
       resolve: 1.22.10
       semver: 7.5.4
       source-map: 0.6.1
@@ -1450,7 +1447,7 @@ packages:
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
-      picomatch: 4.0.3
+      picomatch: 4.0.5
       rollup: 4.50.2
     dev: true
 
@@ -1696,7 +1693,7 @@ packages:
       '@semantic-release/error': 3.0.0
       aggregate-error: 3.1.0
       fs-extra: 11.3.2
-      lodash: 4.17.21
+      lodash: 4.18.1
       semantic-release: 24.2.8(typescript@5.5.4)
     dev: true
 
@@ -1712,7 +1709,7 @@ packages:
       conventional-commits-parser: 6.2.0
       debug: 4.4.3(supports-color@5.5.0)
       import-from-esm: 2.0.0
-      lodash-es: 4.17.21
+      lodash-es: 4.18.1
       micromatch: 4.0.8
       semantic-release: 24.2.8(typescript@5.5.4)
     transitivePeerDependencies:
@@ -1740,7 +1737,7 @@ packages:
       debug: 4.4.3(supports-color@5.5.0)
       dir-glob: 3.0.1
       execa: 5.1.1
-      lodash: 4.17.21
+      lodash: 4.18.1
       micromatch: 4.0.8
       p-reduce: 2.1.0
       semantic-release: 24.2.8(typescript@5.5.4)
@@ -1765,7 +1762,7 @@ packages:
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       issue-parser: 7.0.1
-      lodash-es: 4.17.21
+      lodash-es: 4.18.1
       mime: 4.1.0
       p-filter: 4.1.0
       semantic-release: 24.2.8(typescript@5.5.4)
@@ -1785,7 +1782,7 @@ packages:
       aggregate-error: 5.0.0
       execa: 9.6.0
       fs-extra: 11.3.2
-      lodash-es: 4.17.21
+      lodash-es: 4.18.1
       nerf-dart: 1.0.0
       normalize-url: 8.1.0
       npm: 10.9.3
@@ -1811,7 +1808,7 @@ packages:
       get-stream: 7.0.1
       import-from-esm: 2.0.0
       into-stream: 7.0.0
-      lodash-es: 4.17.21
+      lodash-es: 4.18.1
       read-package-up: 11.0.0
       semantic-release: 24.2.8(typescript@5.5.4)
     transitivePeerDependencies:
@@ -1839,7 +1836,7 @@ packages:
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
       estraverse: 5.3.0
-      picomatch: 4.0.3
+      picomatch: 4.0.5
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -2462,7 +2459,7 @@ packages:
       debug: 4.4.3(supports-color@5.5.0)
       fast-glob: 3.3.3
       is-glob: 4.0.3
-      minimatch: 9.0.5
+      minimatch: 9.0.9
       semver: 7.7.2
       ts-api-utils: 2.1.0(typescript@5.5.4)
       typescript: 5.5.4
@@ -2761,7 +2758,7 @@ packages:
       '@vue/compiler-vue2': 2.7.16
       '@vue/shared': 3.5.21
       computeds: 0.0.1
-      minimatch: 9.0.5
+      minimatch: 9.0.9
       muggle-string: 0.4.1
       path-browserify: 1.0.1
       typescript: 5.5.4
@@ -2780,7 +2777,7 @@ packages:
       '@vue/compiler-vue2': 2.7.16
       '@vue/shared': 3.5.21
       alien-signals: 0.4.14
-      minimatch: 9.0.5
+      minimatch: 9.0.9
       muggle-string: 0.4.1
       path-browserify: 1.0.1
       typescript: 5.5.4
@@ -3053,7 +3050,7 @@ packages:
     engines: {node: '>= 8'}
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 2.3.1
+      picomatch: 2.3.2
     dev: true
 
   /are-docs-informative@0.0.2:
@@ -3096,6 +3093,11 @@ packages:
     resolution: {integrity: sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==}
     dev: true
 
+  /balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+    dev: true
+
   /baseline-browser-mapping@2.8.4:
     resolution: {integrity: sha512-L+YvJwGAgwJBV1p6ffpSTa2KRc69EeeYGYjRVWKs0GKrK+LON0GC0gV+rKSNtALEDvMDqkvCFq9r1r94/Gjwxw==}
     hasBin: true
@@ -3129,6 +3131,13 @@ packages:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
     dependencies:
       balanced-match: 1.0.2
+    dev: true
+
+  /brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
+    dependencies:
+      balanced-match: 4.0.4
     dev: true
 
   /braces@3.0.3:
@@ -3923,7 +3932,7 @@ packages:
       eslint: 9.35.0
       eslint-import-context: 0.1.9(unrs-resolver@1.11.1)
       is-glob: 4.0.3
-      minimatch: 10.0.3
+      minimatch: 9.0.9
       semver: 7.7.2
       stable-hash-x: 0.2.0
       unrs-resolver: 1.11.1
@@ -4036,7 +4045,7 @@ packages:
       debug: 4.4.3(supports-color@5.5.0)
       eslint: 9.35.0
       eslint-compat-utils: 0.6.5(eslint@9.35.0)
-      lodash: 4.17.21
+      lodash: 4.18.1
       toml-eslint-parser: 0.10.0
     transitivePeerDependencies:
       - supports-color
@@ -4193,7 +4202,7 @@ packages:
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
       lodash.merge: 4.6.2
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       natural-compare: 1.4.0
       optionator: 0.9.4
     transitivePeerDependencies:
@@ -4359,16 +4368,16 @@ packages:
       format: 0.2.2
     dev: true
 
-  /fdir@6.5.0(picomatch@4.0.3):
+  /fdir@6.5.0(picomatch@4.0.5):
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: ^3 || ^4
+      picomatch: 4.0.5
     peerDependenciesMeta:
       picomatch:
         optional: true
     dependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.5
     dev: true
 
   /figures@2.0.0:
@@ -4454,7 +4463,7 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
     dependencies:
-      flatted: 3.3.3
+      flatted: 3.4.2
       keyv: 4.5.4
     dev: true
 
@@ -4462,12 +4471,12 @@ packages:
     resolution: {integrity: sha512-ExZSCSV9e7v/Zt7RzCbX57lY2dnPdxzU/h3UE6WJ6NtEMfwBd8jmi1n4otDEUfz+T/R+zxrFDpICFdjhD3H/zw==}
     dependencies:
       cacheable: 2.0.1
-      flatted: 3.3.3
+      flatted: 3.4.2
       hookified: 1.12.0
     dev: true
 
-  /flatted@3.3.3:
-    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+  /flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
     dev: true
 
   /format@0.2.2:
@@ -4793,8 +4802,8 @@ packages:
     engines: {node: '>= 4'}
     dev: true
 
-  /immutable@5.1.3:
-    resolution: {integrity: sha512-+chQdDfvscSF1SJqv2gn4SRO2ZyS3xL3r7IW/wWEEzrzLisnOlKiQu5ytC/BVNcS15C39WT2Hg/bjKjDMcu+zg==}
+  /immutable@5.1.9:
+    resolution: {integrity: sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==}
     dev: true
 
   /import-fresh@3.3.1:
@@ -5225,20 +5234,20 @@ packages:
       p-locate: 6.0.0
     dev: true
 
-  /lodash-es@4.17.21:
-    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
+  /lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
     dev: true
 
-  /lodash-unified@1.0.3(@types/lodash-es@4.17.12)(lodash-es@4.17.21)(lodash@4.17.21):
+  /lodash-unified@1.0.3(@types/lodash-es@4.17.12)(lodash-es@4.18.1)(lodash@4.18.1):
     resolution: {integrity: sha512-WK9qSozxXOD7ZJQlpSqOT+om2ZfcT4yO+03FuzAHD0wF6S0l0090LRPDx3vhTTLZ8cFKpBn+IOcVXK6qOcIlfQ==}
     peerDependencies:
       '@types/lodash-es': '*'
-      lodash: '*'
-      lodash-es: '*'
+      lodash: 4.18.1
+      lodash-es: 4.18.1
     dependencies:
       '@types/lodash-es': 4.17.12
-      lodash: 4.17.21
-      lodash-es: 4.17.21
+      lodash: 4.18.1
+      lodash-es: 4.18.1
     dev: true
 
   /lodash.camelcase@4.3.0:
@@ -5297,8 +5306,8 @@ packages:
     resolution: {integrity: sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==}
     dev: true
 
-  /lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+  /lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
     dev: true
 
   /log-update@6.1.0:
@@ -5803,7 +5812,7 @@ packages:
     engines: {node: '>=8.6'}
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.1
+      picomatch: 2.3.2
     dev: true
 
   /mime@4.1.0:
@@ -5832,21 +5841,21 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /minimatch@10.0.3:
-    resolution: {integrity: sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==}
-    engines: {node: 20 || >=22}
+  /minimatch@10.2.6:
+    resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
+    engines: {node: 18 || 20 || >=22}
     dependencies:
-      '@isaacs/brace-expansion': 5.0.0
+      brace-expansion: 5.0.9
     dev: true
 
-  /minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+  /minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
     dependencies:
       brace-expansion: 1.1.12
     dev: true
 
-  /minimatch@9.0.5:
-    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
+  /minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
     engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
       brace-expansion: 2.0.2
@@ -5937,7 +5946,7 @@ packages:
       chokidar: 3.6.0
       debug: 4.4.3(supports-color@5.5.0)
       ignore-by-default: 1.0.1
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       pstree.remy: 1.1.8
       semver: 7.7.2
       simple-update-notifier: 2.0.0
@@ -6334,13 +6343,13 @@ packages:
   /picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  /picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+  /picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
     dev: true
 
-  /picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+  /picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
     dev: true
 
@@ -6737,7 +6746,7 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
     dependencies:
-      picomatch: 2.3.1
+      picomatch: 2.3.2
     dev: true
 
   /readdirp@4.1.2:
@@ -6892,7 +6901,7 @@ packages:
     hasBin: true
     dependencies:
       chokidar: 4.0.3
-      immutable: 5.1.3
+      immutable: 5.1.9
       source-map-js: 1.2.1
     optionalDependencies:
       '@parcel/watcher': 2.5.1
@@ -6929,7 +6938,7 @@ packages:
       hook-std: 4.0.0
       hosted-git-info: 8.1.0
       import-from-esm: 2.0.0
-      lodash-es: 4.17.21
+      lodash-es: 4.18.1
       marked: 15.0.12
       marked-terminal: 7.3.0(marked@15.0.12)
       micromatch: 4.0.8
@@ -7514,8 +7523,8 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
     dev: true
 
   /tippy.js@6.3.7:
@@ -7562,7 +7571,7 @@ packages:
     peerDependencies:
       typescript: '>=4.0.0'
     dependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.5
       typescript: 5.5.4
     dev: true
 
@@ -7710,7 +7719,7 @@ packages:
     engines: {node: '>=18.12.0'}
     dependencies:
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.5
     dev: true
 
   /unplugin-vue-components@0.27.5(rollup@4.50.2)(vue@3.5.21):
@@ -7733,7 +7742,7 @@ packages:
       fast-glob: 3.3.3
       local-pkg: 0.5.1
       magic-string: 0.30.19
-      minimatch: 9.0.5
+      minimatch: 9.0.9
       mlly: 1.8.0
       unplugin: 1.16.1
       vue: 3.5.21(typescript@5.5.4)
@@ -7933,8 +7942,8 @@ packages:
     dependencies:
       '@types/node': 24.5.1
       esbuild: 0.25.0
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
       postcss: 8.5.6
       rollup: 4.50.2
       sass: 1.92.1
@@ -7952,7 +7961,7 @@ packages:
     resolution: {integrity: sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==}
     engines: {vscode: ^1.52.0}
     dependencies:
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       semver: 7.7.2
       vscode-languageserver-protocol: 3.16.0
     dev: true
@@ -8010,7 +8019,7 @@ packages:
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1
       esquery: 1.6.0
-      lodash: 4.17.21
+      lodash: 4.18.1
       semver: 7.7.2
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
## Summary

Fixes 6 HIGH severity Dependabot alerts in `pnpm-lock.yaml` in one batch, using the existing `pnpm.overrides` pattern. Only `package.json` and `pnpm-lock.yaml` are touched.

| Jira | Package | Before | After | Advisory |
|---|---|---|---|---|
| [QOR5-2891](https://theplanttokyo.atlassian.net/browse/QOR5-2891) | lodash | 4.17.20 / 4.17.21 | 4.18.1 | CVE-2026-4800 |
| [QOR5-2797](https://theplanttokyo.atlassian.net/browse/QOR5-2797) | lodash-es | 4.17.21 | 4.18.1 | CVE-2026-4800 |
| [QOR5-2560](https://theplanttokyo.atlassian.net/browse/QOR5-2560) | minimatch | 3.1.2 / 9.0.5 / 10.0.3 | 3.1.5 / 9.0.9 / 10.2.6 | CVE-2026-27904 |
| [QOR5-2848](https://theplanttokyo.atlassian.net/browse/QOR5-2848) | picomatch | 2.3.1 / 4.0.3 | 2.3.2 / 4.0.5 | GHSA-c2c7-rcm5-vvqj |
| [QOR5-2572](https://theplanttokyo.atlassian.net/browse/QOR5-2572) | immutable | 5.1.3 | 5.1.9 | GHSA-wf6x-7x77-mvgw |
| [QOR5-2647](https://theplanttokyo.atlassian.net/browse/QOR5-2647) | flatted | 3.3.3 | 3.4.2 | GHSA-rf6f-7fwh-wjgh |

Notes:
- minimatch / picomatch: all affected major lines are covered by the same advisories, so 9.x/10.x and 4.x are bumped alongside the flagged ranges.
- Remaining `@types/lodash*@4.17.x` entries in the lockfile are type-definition packages, not affected.
- `lib/` build artifacts are intentionally untouched (rebuild produces only minifier churn; upgraded packages are all devDependencies).

## Verification

- `pnpm build:lib` (vue-tsc type check + vite build + styles) passes.
- Lockfile grep confirms all six packages resolve only to patched versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)